### PR TITLE
Got rid of Groups Page

### DIFF
--- a/SMS-Marketing/Views/Organization/Customers.cshtml
+++ b/SMS-Marketing/Views/Organization/Customers.cshtml
@@ -17,9 +17,9 @@
         <li class="nav-item">
             <a class="nav-link active" asp-action="Customers" asp-controller="Organization" asp-route-id="@Model.Organization.Id">Customers</a>
         </li>
-        <li class="nav-item">
+        <!--<li class="nav-item">
             <a class="nav-link" asp-action="Groups" asp-controller="Organization" asp-route-id="@Model.Organization.Id">Groups</a>
-        </li>
+        </li>-->
         <li class="nav-item">
             <a class="nav-link" asp-action="Insights" asp-controller="Organization" asp-route-id="@Model.Organization.Id">Insights</a>
         </li>

--- a/SMS-Marketing/Views/Organization/Index.cshtml
+++ b/SMS-Marketing/Views/Organization/Index.cshtml
@@ -15,9 +15,9 @@
         <li class="nav-item">
             <a class="nav-link" asp-action="Customers" asp-controller="Organization" asp-route-id="@Model.Id">Customers</a>
         </li>
-        <li class="nav-item">
+        <!--<li class="nav-item">
             <a class="nav-link" asp-action="Groups" asp-controller="Organization" asp-route-id="@Model.Id">Groups</a>
-        </li>
+        </li>-->
         <li class="nav-item">
             <a class="nav-link" asp-action="Insights" asp-controller="Organization" asp-route-id="@Model.Id">Insights</a>
         </li>

--- a/SMS-Marketing/Views/Organization/Insights.cshtml
+++ b/SMS-Marketing/Views/Organization/Insights.cshtml
@@ -16,9 +16,9 @@
         <li class="nav-item">
             <a class="nav-link" asp-action="Customers" asp-controller="Organization" asp-route-id="@Model.Id">Customers</a>
         </li>
-        <li class="nav-item">
+        <!--<li class="nav-item">
             <a class="nav-link" asp-action="Groups" asp-controller="Organization" asp-route-id="@Model.Id">Groups</a>
-        </li>
+        </li>-->
         <li class="nav-item">
             <a class="nav-link active" asp-action="Insights" asp-controller="Organization" asp-route-id="@Model.Id">Insights</a>
         </li>

--- a/SMS-Marketing/Views/Organization/UserManagement.cshtml
+++ b/SMS-Marketing/Views/Organization/UserManagement.cshtml
@@ -16,9 +16,9 @@
         <li class="nav-item">
             <a class="nav-link" asp-action="Customers" asp-controller="Organization" asp-route-id="@Model.Id">Customers</a>
         </li>
-        <li class="nav-item">
+        <!--<li class="nav-item">
             <a class="nav-link" asp-action="Groups" asp-controller="Organization" asp-route-id="@Model.Id">Groups</a>
-        </li>
+        </li>-->
         <li class="nav-item">
             <a class="nav-link" asp-action="Insights" asp-controller="Organization" asp-route-id="@Model.Id">Insights</a>
         </li>


### PR DESCRIPTION
We aren't doing anything with group management at the moment so it's best to get rid of the link and prevent end-users from trying to access a feature that isn't finished yet.